### PR TITLE
Match TextField.Vue file in nova

### DIFF
--- a/resources/js/components/SluggableText/IndexField.vue
+++ b/resources/js/components/SluggableText/IndexField.vue
@@ -1,5 +1,6 @@
 <template>
-    <span>{{ field.value }}</span>
+    <div v-if="field.asHtml" v-html="field.value"></div>
+    <span v-else class="whitespace-no-wrap">{{ field.value }}</span>
 </template>
 
 <script>


### PR DESCRIPTION
The issue is If you have a field that generates html (e.g. through this macro https://github.com/laravel/nova-issues/issues/672 see - linkToDetail) You just see the HTML generated rather than the title and a link to the resource.